### PR TITLE
Fix config view for PHP-FPM

### DIFF
--- a/frontend/views/settings-configuration.php
+++ b/frontend/views/settings-configuration.php
@@ -108,7 +108,7 @@ $permGeneral = $cl->checkPermission(null, PermissionManager::SPECIAL_PERMISSION_
 		<table class='list'>
 			<tr>
 				<th><?php echo LANG('webserver_version'); ?>:</th>
-				<td><?php echo htmlspecialchars(function_exists('apache_get_version') ? apache_get_version() : $_SERVER['SERVER_SOFTWARE']); ?></td>
+				<td><?php echo htmlspecialchars($_SERVER['SERVER_SOFTWARE']??'?'); ?></td>
 			</tr>
 			<tr>
 				<th><?php echo LANG('database_server_version'); ?>:</th>

--- a/frontend/views/settings-configuration.php
+++ b/frontend/views/settings-configuration.php
@@ -108,7 +108,7 @@ $permGeneral = $cl->checkPermission(null, PermissionManager::SPECIAL_PERMISSION_
 		<table class='list'>
 			<tr>
 				<th><?php echo LANG('webserver_version'); ?>:</th>
-				<td><?php echo htmlspecialchars(apache_get_version()); ?></td>
+				<td><?php echo htmlspecialchars(function_exists('apache_get_version') ? apache_get_version() : $_SERVER['SERVER_SOFTWARE']); ?></td>
 			</tr>
 			<tr>
 				<th><?php echo LANG('database_server_version'); ?>:</th>


### PR DESCRIPTION
On my webserver using PHP-FPM I always got an error 500 when opening the configuration view (`https://oco.example.com/?view=settings-configuration`). `/var/log/apache2/oco-error.log` shows:
```
[Sat May 18 01:17:41.855796 2024] [proxy_fcgi:error] [pid 74192:tid 139780300166720] [remote 192.168.1.2:64211] AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function apache_get_version() in /var/www/oco/frontend/views/settings-configuration.php:111\nStack trace:\n#0 {main}\n  thrown in /var/www/oco/frontend/views/settings-configuration.php on line 111', referer: https://oco.example.com/?view=settings
```

This quick fix falls back onto `$_SERVER['SERVER_SOFTWARE']` when `apache_get_version()` is unavailable, but there may be a more suitable way to retrieve the info. The result looks like this:

![grafik](https://github.com/schorschii/OCO-Server/assets/54958084/fa937c0c-9752-4f55-8c16-df11fe54789a)

Everything above was just reproduced using OCO server v1.0.4, but I had been using it on commit ad6689c with this little fix since October. During this time, I didn't encounter any other compatibility issues with PHP-FPM, so good job! Generally, thank you for this great piece of software.