### PR TITLE
Fix: Move curl_getinfo before curl_close in AndroidEnrollment.class.php

### DIFF
--- a/lib/Android/AndroidEnrollment.class.php
+++ b/lib/Android/AndroidEnrollment.class.php
@@ -128,10 +128,11 @@ class AndroidEnrollment {
 				'Content-Type: application/json',
 			] : $header
 		);
-		$response = curl_exec($ch);
-		curl_close($ch);
 
+		$response = curl_exec($ch);
 		$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		curl_close($ch);
+		
 		if($expectedStatusCode && $statusCode !== $expectedStatusCode)
 			throw new \Exception('Unexpected status code '.$statusCode.' '.$response);
 


### PR DESCRIPTION
This fixes the 'not a valid cURL handle resource' warning that occurs when trying to generate an Android MDM Signup URL.